### PR TITLE
Add lang option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ Reveal.initialize({
         lastKeyword: 'lastslide',     // default gotolast
         firstKeyword: 'firstslide',   // default gotofirst
         debug: true,                  // default false
-        lang: 'de-DE'                 // default '' (Reference: https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/lang)
+        lang: 'de-DE'                 // default ''
       });
     }
   }]
 });
 ```
+
+More info on the `lang` attribute can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/lang).
 
 #### Browser Support
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Reveal.initialize({
         prevKeyword: 'previousslide', // default gotoprevious
         lastKeyword: 'lastslide',     // default gotolast
         firstKeyword: 'firstslide',   // default gotofirst
-        debug: true                   // default false
+        debug: true,                  // default false
+        lang: 'de-DE'                 // default '' (Reference: https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/lang)
       });
     }
   }]

--- a/speech.js
+++ b/speech.js
@@ -10,7 +10,8 @@ var RevealSpeech = (function() {
     prevKeyword: 'gotoprevious',
     lastKeyword: 'gotolast',
     firstKeyword: 'gotofirst',
-    debug: false
+    debug: false,
+    lang: ''
   };
 
   function configure(options) {
@@ -33,6 +34,7 @@ var RevealSpeech = (function() {
   var recognition = new webkitSpeechRecognition();
   recognition.continuous = true;
   recognition.interimResults = true;
+  recognition.lang = config.lang;
 
   Reveal.addEventListener('slidechanged', function(event) {
     fragmentIndex = 0;


### PR DESCRIPTION
@qsys
This addresses your issue #1 
Default is empty, following [this spec](https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html#dfn-lang) for the `lang` attribute. Let me know if there are any adjustments you'd like to see made before merging in.